### PR TITLE
Fixed API 

### DIFF
--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,6 +1,6 @@
 let apiUrl
 const apiUrls = {
-  production: 'https://fathomless-castle-00355.herokuapp.com',
+  production: 'https://patrick-dohn-kettle-api.herokuapp.com/',
   development: 'http://localhost:4741'
 }
 

--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,6 +1,6 @@
 let apiUrl
 const apiUrls = {
-  production: 'https://patrick-dohn-kettle-api.herokuapp.com/',
+  production: 'https://patrick-dohn-kettle-api.herokuapp.com',
   development: 'http://localhost:4741'
 }
 


### PR DESCRIPTION
switched API to mongo Atlas because Heroku no longer supports mongo labs and was currently broken.